### PR TITLE
DSFプラグイン

### DIFF
--- a/STEP_dsf/Id3tagv2_for_dsf.cpp
+++ b/STEP_dsf/Id3tagv2_for_dsf.cpp
@@ -2068,12 +2068,12 @@ DWORD CId3tagv2::DelTag(LPCTSTR szFileName)
 
     TCHAR szTempPath[MAX_PATH];
     TCHAR szTempFile[MAX_PATH];
-
+#if 0	// 強制削除にする為、チェック不要にする
     if(!m_bEnable)
     {
         return -1;
     }
-
+#endif
     //==================元ファイルをメモリに保存==================
     HANDLE hFile = CreateFile(
                             szFileName,


### PR DESCRIPTION
・保存においてPointer to Metadata chunkが自分のファイルサイズ以上だった場合は強制書込みを行うようにした。 ・タグ削除においてDSFファイルはファイル後尾にタグがあるので強制削除しても問題ない為、タグチェックしないで（強制）削除するようにした。

DJ-TOYOさんに頂きました https://github.com/jarupxx/STEP_J/issues/1 の修正です